### PR TITLE
Rename Test names so we don't overwrite tests in adds

### DIFF
--- a/demo-function-kafka-send/src/test/java/org/devnexus/function/DemoFunctionKafakSendTests.java
+++ b/demo-function-kafka-send/src/test/java/org/devnexus/function/DemoFunctionKafakSendTests.java
@@ -11,7 +11,7 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.messaging.support.MessageBuilder;
 
 @SpringBootTest
-class DemoFunctionApplicationTests {
+class DemoFunctionKafakSendTests {
 	
 	@Autowired
 	private ProducerFactory<String, String> producerFactory;

--- a/demo-function-web/README.md
+++ b/demo-function-web/README.md
@@ -24,5 +24,5 @@ java -jar target/demo-function-web-0.0.1-SNAPSHOT.jar
 
 #### Send Sample Data
 ```
-curl -X POST  -i -H "Accept: application/json" localhost:8080/placeOrder -d '{"id": "foo","description":"fooproduct","date":"2024-03-03"}'
+curl -X POST  -i -H "Content-Type: application/json" localhost:8080/placeOrder -d '{"id":"6a88842c-5cd8-4207-8889-c4fd845d646a","description":"My amazing order","date":1710003590392}'
 ```

--- a/demo-function-web/src/test/java/org/devnexus/function/DemoFunctionWebTests.java
+++ b/demo-function-web/src/test/java/org/devnexus/function/DemoFunctionWebTests.java
@@ -16,7 +16,7 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "spring.main.web-application-type=servlet")
-class DemoFunctionApplicationTests {
+class DemoFunctionWebTests {
 	
 	@Autowired
 	private TestRestTemplate resetTemplate;


### PR DESCRIPTION
Currently when we add we overwrite our original function test which we want to keep.
With this change we create a new test that will test the web functionality (and our kafka tests).
Also updated the readme to fix a hiccup in the curl command.